### PR TITLE
Fix build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+build/

--- a/include/t9/io.h
+++ b/include/t9/io.h
@@ -60,7 +60,7 @@ t9_file_exists(const char *const path, uint8_t *const exists);
  * @return T9_SUCCESS on success, T9_FAILURE otherwise.
  */
 t9_error_t
-t9_file_size(const char *const path, uint64_t *const size);
+t9_file_size(const char *const path, size_t *const size);
 
 /*!
  * Read the content of a file to memory.


### PR DESCRIPTION
Fixed a build error:
```
[2/13] Compiling C object 'c-t9@exe/src_t9_io.c.o'.
FAILED: c-t9@exe/src_t9_io.c.o 
cc -Ic-t9@exe -I. -I.. -Iinclude -I../include -Xclang -fcolor-diagnostics -pipe -Wall -Winvalid-pch -std=c11 -g -pedantic -Wall -Wextra -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wbad-function-cast -Wsign-compare -Wnested-externs -Wshadow -Waggregate-return -Wcast-align -Wold-style-definition -Wdeclaration-after-statement -Wuninitialized -DGNUC -DGNU_COMPILER -MD -MQ 'c-t9@exe/src_t9_io.c.o' -MF 'c-t9@exe/src_t9_io.c.o.d' -o 'c-t9@exe/src_t9_io.c.o' -c ../src/t9/io.c
../src/t9/io.c:55:1: error: conflicting types for 't9_file_size'
t9_file_size(const char *const path, size_t *const size) {
^
../include/t9/io.h:63:1: note: previous declaration is here
t9_file_size(const char *const path, uint64_t *const size);
^
../src/t9/io.c:101:28: warning: incompatible pointer types passing 'size_t *' (aka 'unsigned long *') to parameter of type 'uint64_t *' (aka 'unsigned long long *') [-Wincompatible-pointer-types]
    if (t9_file_size(path, &file_size) != T9_SUCCESS) {
                           ^~~~~~~~~~
../include/t9/io.h:63:54: note: passing argument to parameter 'size' here
t9_file_size(const char *const path, uint64_t *const size);
                                                     ^
../src/t9/io.c:140:2: warning: no newline at end of file [-Wnewline-eof]
}
 ^
2 warnings and 1 error generated.
[3/13] Compiling C object 'c-t9@exe/src_t9_math.c.o'.
../src/t9/math.c:46:2: warning: no newline at end of file [-Wnewline-eof]
}
 ^
1 warning generated.
[4/13] Compiling C object 'c-t9@exe/src_t9_corpus.c.o'.
../src/t9/corpus.c:236:2: warning: no newline at end of file [-Wnewline-eof]
}
 ^
1 warning generated.
[7/13] Compiling C object 'c-t9@exe/src_t9_timer.c.o'.
../src/t9/timer.c:75:2: warning: no newline at end of file [-Wnewline-eof]
}
 ^
1 warning generated.
ninja: build stopped: subcommand failed.
```